### PR TITLE
Added uuv_gazebo_worlds and uuv_simulation_wrapper as dependencies

### DIFF
--- a/rexrov2_gazebo/package.xml
+++ b/rexrov2_gazebo/package.xml
@@ -18,5 +18,7 @@
 
   <exec_depend>rexrov2_description</exec_depend>
   <exec_depend>rexrov2_control</exec_depend>
+  <exec_depend>uuv_simulation_wrapper</exec_depend>
+  <exec_depend>uuv_gazebo_worlds</exec_depend>
 
 </package>


### PR DESCRIPTION
Added uuv_gazebo_worlds and uuv_simulation_wrapper as execution dependency into rexrov2_gazebo, because they are used in start_demo_pid_controller.launch.